### PR TITLE
Frontend updates for shiny 1.8.0 and bslib 0.6.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gMCPShiny
 Title: Shiny App for Graphical Multiplicity
-Version: 2023.5.0
+Version: 2023.11.0
 Authors@R: c(
     person("Yalin", "Zhu", email = "yalin.zhu@outlook.com", role = "aut",
            comment = c(ORCID = "0000-0003-3830-8660")),

--- a/inst/app/DESCRIPTION
+++ b/inst/app/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gMCPShiny
 Title: gMCP Shiny App
 Type: Shiny
-Version: 2023.5.0
+Version: 2023.11.0
 Imports:
     brew,
     bslib,

--- a/inst/app/ui/main.R
+++ b/inst/app/ui/main.R
@@ -7,6 +7,7 @@ navbarFluidPage(
   lang = "en",
   theme = bslib::bs_theme(
     version = 5,
+    preset = "bootstrap",
     primary = "#00857c",
     "navbar-light-brand-color" = "#212529",
     "navbar-light-brand-hover-color" = "#212529",

--- a/inst/app/www/css/custom.css
+++ b/inst/app/www/css/custom.css
@@ -60,3 +60,10 @@ a[data-toggle='popover'] {
 .popover-header {
     margin-top: 0
 }
+
+/* reset file button radius */
+/* https://github.com/rstudio/shiny/pull/3879 */
+.input-group>.input-group-prepend>.btn {
+    border-top-right-radius: var(--bs-border-radius);
+    border-bottom-right-radius: var(--bs-border-radius);
+}


### PR DESCRIPTION
This PR:

- Use `preset = "bootstrap"` due to bslib 0.6.0 default changing to `preset = "shiny"` which yields a non-consistent appearance for various components with no significant aesthetic or practical gains.
- Reset file button radius due to shiny 1.8.0 setting them to 0.